### PR TITLE
refactor: Rename 'title' to 'item_name' and 'medium' to 'category' 

### DIFF
--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -20,8 +20,8 @@ CREATE TABLE moods (
 
 CREATE TABLE recommendations (
     id SERIAL PRIMARY KEY,
-    title TEXT NOT NULL,
-    medium TEXT NOT NULL,
+    item_name TEXT NOT NULL,
+    category TEXT NOT NULL,
     recommender TEXT,
     user_id INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL,
     status TEXT DEFAULT 'pending',


### PR DESCRIPTION
This PR updates our database schema (`schema.sql`) to reflect the agreed-upon naming conventions (from our Slack discussion).

**Changes:**

-   `recommendations` table:
    -   Column `title` renamed to `item_name`.
    -   Column `medium` renamed to `category`.


Please review this PR. **Once approved, I will merge it.**

Thanks!